### PR TITLE
Msys2/1.66.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,8 @@ class BoostBuildConan(ConanFile):
                         os.path.join('build', 'src', 'util', 'os.jam'))
 
     def build(self):
-        command = "bootstrap" if self.settings.os == "Windows" else "./bootstrap.sh"
+        use_windows_commands = os.name == 'nt'
+        command = "bootstrap" if use_windows_commands else "./bootstrap.sh"
         build_dir = os.path.join(self.source_folder, "build")
         vscmd_path = os.path.join(build_dir, "src", "engine")
         os.chdir(build_dir)
@@ -38,14 +39,11 @@ class BoostBuildConan(ConanFile):
             try:
                 self.run(command)
             except:
-                if self.settings.os == "Windows":
-                    read_cmd = "type"
-                else:
-                    read_cmd = "cat"
+                read_cmd = "type" if use_windows_commands else "cat"
                 self.run("{0} bootstrap.log".format(read_cmd))
                 raise
 
-        command = "b2" if self.settings.os == "Windows" else "./b2"
+        command = "b2" if use_windows_commands else "./b2"
         full_command = "{0} --prefix=../output --abbreviate-paths".format(command)
         self.run(full_command)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,26 +14,26 @@ class BoostBuildConan(ConanFile):
     license = "BSL-1.0"
     author = "Bincrafters <bincrafters@gmail.com>"
     exports = ["LICENSE.md"]
-    settings = "os", "arch"    
+    settings = "os", "arch"
     lib_short_names = ["build"]
     exports_sources = "*.jam"
-          
+
     def source(self):
         boostorg_github = "https://github.com/boostorg"
-        archive_name = "boost-" + self.version  
+        archive_name = "boost-" + self.version
         for lib_short_name in self.lib_short_names:
             tools.get("{0}/{1}/archive/{2}.tar.gz"
-                .format(boostorg_github, lib_short_name, archive_name))
+                      .format(boostorg_github, lib_short_name, archive_name))
             os.rename(lib_short_name + "-" + archive_name, lib_short_name)
         shutil.copyfile('os.jam',
-            os.path.join('build','src','util','os.jam'))
+                        os.path.join('build', 'src', 'util', 'os.jam'))
 
     def build(self):
         command = "bootstrap" if self.settings.os == "Windows" else "./bootstrap.sh"
         build_dir = os.path.join(self.source_folder, "build")
         vscmd_path = os.path.join(build_dir, "src", "engine")
         os.chdir(build_dir)
-        
+
         with tools.environment_append({"VSCMD_START_DIR": vscmd_path}):
             try:
                 self.run(command)
@@ -53,7 +53,7 @@ class BoostBuildConan(ConanFile):
         self.copy(pattern="*b2", dst="", src="output")
         self.copy(pattern="*b2.exe", dst="", src="output")
         self.copy(pattern="*.jam", dst="", src="output")
-        
+
     def package_info(self):
         self.cpp_info.bindirs = ["bin"]
         self.env_info.path = [os.path.join(self.package_folder, "bin")] + self.env_info.path


### PR DESCRIPTION
addresses https://github.com/bincrafters/community/issues/205

use windows-style commands only in real windows environment
checks are modified to use **os.name** instead of conan os setting for two reasons:

- windows-style commands fail in case of MSYS, Cygwin and similar environments
- also, in case of cross-compiling, os doesn't represent OS of build environment, but OS of target platform (e.g. real use-case is to cross compile for Android from Windows)