### PR TITLE
Cross compiling/1.66.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class BoostBuildConan(ConanFile):
     license = "BSL-1.0"
     author = "Bincrafters <bincrafters@gmail.com>"
     exports = ["LICENSE.md"]
-    settings = "os", "arch"
+    settings = "os_build", "arch_build"
     lib_short_names = ["build"]
     exports_sources = "*.jam"
 


### PR DESCRIPTION
use **os_build** and **arch_build** settings instead of **os** and **arch**
this helps for cross-compiling (e.g. from Linux to Windows)
related to the https://github.com/bincrafters/community/issues/353