### PR TITLE
set BOOST_BUILD_PATH as a list

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -58,4 +58,4 @@ class BoostBuildConan(ConanFile):
     def package_info(self):
         self.cpp_info.bindirs = ["bin"]
         self.env_info.path = [os.path.join(self.package_folder, "bin")] + self.env_info.path
-        self.env_info.BOOST_BUILD_PATH = os.path.join(self.package_folder, "share", "boost-build", "src", "kernel")
+        self.env_info.BOOST_BUILD_PATH = [os.path.join(self.package_folder, "share", "boost-build", "src", "kernel")]


### PR DESCRIPTION
Set `BOOST_BUILD_PATH` as a list instead of a string in `package_info` method. Fixes bincrafters/community#725.